### PR TITLE
UHF-X: Changed the front page to point to correct place

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -1,3 +1,4 @@
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
-ignored_config_entities: null
+ignored_config_entities:
+  - 'hdbt_admin_tools.site_settings:site_settings'

--- a/conf/cmi/hdbt_admin_tools.site_settings.yml
+++ b/conf/cmi/hdbt_admin_tools.site_settings.yml
@@ -2,12 +2,12 @@ _core:
   default_config_hash: 3ooO-bLkru7Jl91Kb8hO7pD1divveu98PTIZQiCV3pQ
 langcode: en
 site_settings:
-  theme_color: coat-of-arms
   default_icon: home-smoke
+  theme_color: coat-of-arms
   koro: basic
 footer_settings:
   footer_color: dark
-  footer_top_content:
-    format: full_html
-    value: "<ul class=\"menu\"><li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Helsinki-info advisory service\" data-protocol=\"false\" href=\"https://www.hel.fi/kanslia/neuvonta-en/\">Helsinki-info advisory service</a></li><li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Contact information search\" data-protocol=\"false\" href=\"https://numerot.hel.fi/\">Contact information search</a></li><li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Give feedback\" data-protocol=\"false\" href=\"https://www.hel.fi/feedback/\">Give feedback</a></li></ul>\r\n"
   footer_top_title: 'Contact us'
+  footer_top_content:
+    value: "<ul class=\"menu\"><li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Helsinki-info advisory service\" data-protocol=\"false\" href=\"https://www.hel.fi/kanslia/neuvonta-en/\">Helsinki-info advisory service</a></li><li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Contact information search\" data-protocol=\"false\" href=\"https://numerot.hel.fi/\">Contact information search</a></li><li class=\"menu__item menu__item--external\"><a class=\"link\" data-design=\"link\" data-link-text=\"Give feedback\" data-protocol=\"false\" href=\"https://www.hel.fi/feedback/\">Give feedback</a></li></ul>\r\n"
+    format: full_html

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /user/login
+  front: /node/1
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en


### PR DESCRIPTION
# UHF-X: Changed the front page to point to correct place
<!-- What problem does this solve? -->
Front page is reset to /user every time when new code is deployed - we needed to change that.

## What was done
<!-- Describe what was done -->

* Configure correct node to front page (it is node/1 on production)
* Added the config to config ignore so that it will be ignored from here on out.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-X_front_page_configuration`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that node/1 is set as the front page of the site.
* [x] Check that the configuration is ignored if you change it from https://helfi-kuva.docker.so/fi/kulttuuri-ja-vapaa-aika/admin/config/system/site-information and try to export it.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
