### PR TITLE
UHF-7241: Updated Swedish translation of front page breadcrumb link

### DIFF
--- a/conf/cmi/language/sv/metatag.metatag_defaults.front.yml
+++ b/conf/cmi/language/sv/metatag.metatag_defaults.front.yml
@@ -1,1 +1,1 @@
-label: Startsida
+label: Huvudsida


### PR DESCRIPTION
# [UHF-7241](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7241)
<!-- What problem does this solve? -->
Swedish front page link in the breadcrumb has wrong translation.

## What was done
<!-- Describe what was done -->

* Updated Swedish translation of front page breadcrumb link.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7241_kuva-breadcrumb-translation-fix`
* Run `make drush-cim`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the front page link text in the breadcrumb on Swedish pages says **Huvudsida**.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
