### PR TITLE
update navigation to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "drupal/hdbt_admin": "^1.0",
         "drupal/helfi_azure_fs": "^1.0",
         "drupal/helfi_drupal_tools": "dev-main",
-        "drupal/helfi_navigation": "^1.0",
+        "drupal/helfi_navigation": "^2.0",
         "drupal/helfi_platform_config": "^2.0",
         "drupal/helfi_proxy": "^3.0",
         "drupal/helfi_tpr": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c7168085c5bf2435555f98bd226b782",
+    "content-hash": "36d589681ec4c0633fb9d7dabd71561d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4342,20 +4342,21 @@
         },
         {
             "name": "drupal/helfi_navigation",
-            "version": "1.1.0",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-navigation.git",
-                "reference": "98e3a83bf68d002b1dfc7ca8aa6b06e33788833c"
+                "reference": "e8a7a7e74cd2f77d322c352d0778276df2bd1be6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-navigation/zipball/98e3a83bf68d002b1dfc7ca8aa6b06e33788833c",
-                "reference": "98e3a83bf68d002b1dfc7ca8aa6b06e33788833c",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-navigation/zipball/e8a7a7e74cd2f77d322c352d0778276df2bd1be6",
+                "reference": "e8a7a7e74cd2f77d322c352d0778276df2bd1be6",
                 "shasum": ""
             },
             "require": {
                 "drupal/helfi_api_base": "*",
+                "ext-curl": "*",
                 "php": "^8.0"
             },
             "require-dev": {
@@ -4368,10 +4369,10 @@
             ],
             "description": "Helfi - Navigation",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/tree/1.1.0",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/tree/2.0.3",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/issues"
             },
-            "time": "2023-01-13T09:32:25+00:00"
+            "time": "2023-02-17T12:43:22+00:00"
         },
         {
             "name": "drupal/helfi_platform_config",


### PR DESCRIPTION
Bumped helfi_navigation version to 2.x

run `git checkout UHF-X_nav_version`
run `make fresh`

- Setup etusivu also
- Add navigation key to this sites local.settings.php: `$config['helfi_navigation.api']['key'] = 'abcdefg';`
- Edit and save the main navigation on this site
- run `drush cron`
- Go to etusivu-instance:
- global navigation entity should have updated