### PR TITLE
UHF-8595: Exported kuva specific unit display configs.

### DIFF
--- a/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_form_display.tpr_unit.tpr_unit.default.yml
@@ -118,7 +118,7 @@ content:
     region: content
     settings:
       title: Paragraph
-      title_plural: Paragraphs
+      title_plural: Lohkot
       edit_mode: open
       closed_mode: summary
       autocollapse: none
@@ -137,7 +137,7 @@ content:
     region: content
     settings:
       title: Paragraph
-      title_plural: Paragraphs
+      title_plural: Lohkot
       edit_mode: open
       closed_mode: summary
       autocollapse: none
@@ -156,6 +156,7 @@ content:
     region: content
     settings:
       sidebar: false
+      use_details: true
     third_party_settings: {  }
   field_unit_type:
     type: entity_reference_autocomplete
@@ -373,4 +374,3 @@ hidden:
   created: true
   hide_description: true
   ontologyword_ids: true
-  show_www: true

--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -45,7 +45,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 21
+    weight: 23
     region: content
   accessibility_www:
     type: link
@@ -86,7 +86,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 26
+    weight: 19
     region: content
   description:
     type: text_default
@@ -110,7 +110,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 20
+    weight: 22
     region: content
   field_lower_content:
     type: entity_reference_revisions_entity_view
@@ -119,7 +119,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 22
+    weight: 24
     region: content
   field_metatags:
     type: metatag_empty_formatter
@@ -133,14 +133,14 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 24
+    weight: 26
     region: content
   links:
     type: tpr_connection
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 25
+    weight: 20
     region: content
   name:
     type: string
@@ -170,7 +170,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 18
+    weight: 21
     region: content
   phone:
     type: telephone_link
@@ -203,7 +203,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 19
+    weight: 18
     region: content
   provided_languages:
     type: string
@@ -211,7 +211,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 23
+    weight: 25
     region: content
   service_map_embed:
     type: service_map_embed


### PR DESCRIPTION
# [UHF-8595](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8595)
<!-- What problem does this solve? -->
Kuva needs its own display configs for form and view modes.

## What was done
<!-- Describe what was done -->

* Display new TPR fields in form and view displays.

## How to install

* Make sure your kuva instance is up and running on correct branch.
  * `git checkout UHF-8595_Unit-display-configs`
  * `composer require drupal/hdbt` to be sure to have the latest
  * `composer require drupal/helfi_tpr` to be sure to have the latest
  * `composer require drupal/helfi_platform_config:dev-UHF-8595_Revert-unit-display-config-changes`
  * `make fresh`
* Run `drush migrate:import tpr_unit --idlist 41047:fi,41047:sv,41047:en --update`
* Run `make drush-updb drush-cr drush-cim`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check https://helfi-kuva.docker.so/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/uimarannat/maauimalat/uimastadion and that the new fields are visible (charges, further information, web sites and other contact information)

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
Also check this one: https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/542.


[UHF-8595]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ