### PR TITLE
UHF-8802: Non-linguistic URLs

### DIFF
--- a/conf/cmi/helfi_proxy.settings.yml
+++ b/conf/cmi/helfi_proxy.settings.yml
@@ -6,3 +6,4 @@ prefixes:
   fi: kulttuuri-ja-vapaa-aika
   sv: kultur-och-fritid
   ru: culture-and-leisure
+  zxx: culture-and-leisure

--- a/public/sites/default/staging.settings.php
+++ b/public/sites/default/staging.settings.php
@@ -8,4 +8,5 @@ $config['helfi_proxy.settings']['prefixes'] = [
   'fi' => 'staging-kulttuuri-ja-vapaa-aika',
   'sv' => 'staging-kultur-och-fritid',
   'ru' => 'staging-culture-and-leisure',
+  'zxx' => 'staging-culture-and-leisure',
 ];

--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -8,6 +8,7 @@ $config['helfi_proxy.settings']['prefixes'] = [
   'fi' => 'test-kulttuuri-ja-vapaa-aika',
   'sv' => 'test-kultur-och-fritid',
   'ru' => 'test-culture-and-leisure',
+  'zxx' => 'test-culture-and-leisure',
 ];
 
 $config['helfi_global_announcement.settings']['source_environment'] = 'test';


### PR DESCRIPTION
# [UHF-8802](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8802)
<!-- What problem does this solve? -->

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8802`
* Run `drush updb` and `drush cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure sitemap.xml works through `/culture-and-leisure/sitemap.xml` and the page does not perform any redirects


[UHF-8802]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ