### PR TITLE
Reverted unwanted changes to new tpr unit field display configs.

### DIFF
--- a/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
+++ b/conf/cmi/core.entity_view_display.tpr_unit.tpr_unit.default.yml
@@ -18,7 +18,7 @@ dependencies:
     - telephone
     - text
 _core:
-  default_config_hash: eEYHiODeZDTb8z0FJIhd8OeomGNTM2nh51IdmVBQBqc
+  default_config_hash: DOuUkveApF8w1Src7sCS9GnmmA_IpAqLzHYZYzCmPPk
 id: tpr_unit.tpr_unit.default
 targetEntityType: tpr_unit
 bundle: tpr_unit
@@ -45,7 +45,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 19
+    weight: 21
     region: content
   accessibility_www:
     type: link
@@ -81,6 +81,13 @@ content:
     third_party_settings: {  }
     weight: 11
     region: content
+  contacts:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 26
+    region: content
   description:
     type: text_default
     label: hidden
@@ -103,7 +110,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 18
+    weight: 20
     region: content
   field_lower_content:
     type: entity_reference_revisions_entity_view
@@ -112,7 +119,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 20
+    weight: 22
     region: content
   field_metatags:
     type: metatag_empty_formatter
@@ -126,7 +133,14 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 22
+    weight: 24
+    region: content
+  links:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 25
     region: content
   name:
     type: string
@@ -150,6 +164,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 7
+    region: content
+  other_info:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 18
     region: content
   phone:
     type: telephone_link
@@ -177,13 +198,20 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
+  price_info:
+    type: tpr_connection
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 19
+    region: content
   provided_languages:
     type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 21
+    weight: 23
     region: content
   service_map_embed:
     type: service_map_embed
@@ -216,15 +244,11 @@ content:
     weight: 12
     region: content
 hidden:
-  contacts: true
   created: true
   field_unit_type: true
   hide_description: true
   langcode: true
   latitude: true
-  links: true
   longitude: true
-  other_info: true
-  price_info: true
   show_www: true
   streetview_entrance_url: true


### PR DESCRIPTION
# UHF-X
<!-- What problem does this solve? -->
Some unwanted config changes were accidentally merged in an automatic PR: https://github.com/City-of-Helsinki/drupal-helfi-kuva/pull/209.

## What was done
<!-- Describe what was done -->

* Reverted the changes

## How to install

* Make sure your kuva instance is up and running on correct branch.
  * `git checkout UHF-X_Revert-unwanted-tpr-unit-changes`
  * `make fresh`
* Run `make drush-cim drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that [Uimastadion page](https://helfi-kuva.docker.so/fi/kulttuuri-ja-vapaa-aika/ulkoilu-puistot-ja-luontokohteet/uimarannat/maauimalat/uimastadion) has web sites, other contact information, further information and charges fields visible.
* [ ] Check that there are no other unwanted changes in this change.
