### PR TITLE
UHF-5985 ad role mapping

### DIFF
--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -12,3 +12,5 @@ $config['helfi_proxy.settings']['prefixes'] = [
 ];
 
 $config['helfi_global_announcement.settings']['source_environment'] = 'test';
+
+$config['openid_connect.client.tunnistamo']['settings']['debug_log'] = TRUE;

--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -14,3 +14,17 @@ $config['helfi_proxy.settings']['prefixes'] = [
 $config['helfi_global_announcement.settings']['source_environment'] = 'test';
 
 $config['openid_connect.client.tunnistamo']['settings']['debug_log'] = TRUE;
+$config['openid_connect.client.tunnistamo']['settings']['ad_roles'] = [
+  [
+    'ad_role' => 'Drupal_Helfi_kaupunkitaso_paakayttajat',
+    'roles' => ['admin'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Kulttuuri_ja_vapaa-aika_sisallontuottajat_laaja',
+    'roles' => ['editor'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Kulttuuri_ja_vapaa-aika_sisallontuottajat_suppea',
+    'roles' => ['content_producer'],
+  ],
+];


### PR DESCRIPTION
# [UHF-5985](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5985)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Test AD role mapping.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-5985-ad-role-mapping`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Test role mapping in testing environment
* [ ] See debug logging from tunnistamo module.

## Other PRs
<!-- For example an related PR in another repository -->

* [Link to other PR](https://github.com/City-of-Helsinki/drupal-module-helfi-tunnistamo/pull/31)


[UHF-5985]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-5985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ