### PR TITLE
Proper weight for user_inquiry block

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_user_inquiry.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_user_inquiry.yml
@@ -11,7 +11,7 @@ dependencies:
 id: hdbt_subtheme_user_inquiry
 theme: hdbt
 region: attachments
-weight: 0
+weight: -19
 provider: helfi_platform_config
 plugin: chat_leijuke
 settings:


### PR DESCRIPTION
User inquiry block should be before other leijuke-blocks. Otherwise it may break the blocks that are before it. Only in Sote and Kuva